### PR TITLE
Zip isn't default installed on all arch based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You will need a Diablo II installation to work! (the script will ask you for the
 
 ### Arch
 ```
-sudo pacman -S zenity curl p7zip unrar jq wmctrl fuse2
+sudo pacman -S zenity curl p7zip unrar jq wmctrl fuse2 zip
 ```
 
 ### Debian/Ubuntu/elementaryOS


### PR DESCRIPTION
Tried the script on a manjaro installation, when trying to update the median xl version the launcher says success but failed in the logs because zip wasn't installed.


Thanks for creating the project!