### PR TITLE
Added PKGBUILD and additional instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ You will need a Diablo II installation to work! (the script will ask you for the
 sudo pacman -S wine zenity curl p7zip unrar jq wmctrl fuse2 zip xdelta3
 ```
 
+Or install from PKGBUILD for archlinux users (using makepkg)
+
+```
+git clone https://github.com/murkl/d2launcher.git
+cd aur
+makepkg -si
+```
+
 ### Debian/Ubuntu/elementaryOS
 
 ```

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,15 @@
+pkgname=d2launcher
+pkgver=3.5.0
+pkgrel=1
+pkgdesc="Launcher for D2, Median XL, and D2 Stats"
+arch=('any')
+url="https://github.com/murkl/d2launcher"
+license=('unknown')
+depends=(wine zenity curl p7zip unrar jq wmctrl fuse2 zip xdelta3)
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/murkl/d2launcher/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('0753b6edbae8c742914575f60b0bcbed5405f0d2feb36ffbd7c2720e5e3a7208')
+
+package() {
+	cd "${srcdir}/${pkgname}-${pkgver}"
+    install -D d2launcher "$pkgdir/usr/bin/d2launcher"
+}


### PR DESCRIPTION
First off, nice little launcher you have here...

Maintaining an Arch system gets to be a pain when you install a lot of little dependencies and they're not linked to anything. I, at least, tend to forgetting why I installed things after a while! Thankfully, writing a PKGBUILD file is very straight forward and will properly mark dependent packages as dependencies so they can be managed properly by pacman.

I set up the PKGBUILD to use the same version as the your latest tag (currently 3.5.0). If you end up tagging another release, you'll have to update the 'pkgver' variable to match (sorry to give you extra work!). I'm not interested in maintaining this package in the AUR, but if you'd like to go through the process see the [AUR submission guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines) - it's pretty easy.

Thanks again for putting this all together!


