### PR TITLE
[fix] Make the launcher compatible with zenity 4.0

### DIFF
--- a/d2launcher
+++ b/d2launcher
@@ -832,7 +832,7 @@ exec_d2_video_settings() {
 # /////////////////////////////////////////////////////
 
 zenity() {
-    /usr/bin/zenity --class="d2launcher" --name="d2launcher" --title="" --window-icon="$SCRIPT_ICON_FILE" --width="$gui_width" --height="$gui_height" "$@" 2>/dev/null
+    /usr/bin/zenity --title="" --window-icon="$SCRIPT_ICON_FILE" --width="$gui_width" --height="$gui_height" "$@" 2>/dev/null
 }
 
 zenity_dialog() {


### PR DESCRIPTION
Seems like Zenity 4.0 doesn't support `class` and `name` parameters. Currently launcher refuses to open the main menu because of this.